### PR TITLE
chore(storybook): add aliases for @tidbcloud/uikit

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,4 +21,5 @@ const config: StorybookConfig = {
     autodocs: true
   }
 }
+
 export default config

--- a/.storybook/vite.config.js
+++ b/.storybook/vite.config.js
@@ -1,4 +1,17 @@
+import path from 'node:path'
+import process from 'node:process'
 import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
-export default defineConfig({})
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: /^@tidbcloud\/uikit\/theme$/, replacement: path.resolve(process.cwd(), './packages/uikit/src/theme') },
+      { find: /^@tidbcloud\/uikit\/hooks$/, replacement: path.resolve(process.cwd(), './packages/uikit/src/hooks') },
+      { find: /^@tidbcloud\/uikit\/icons$/, replacement: path.resolve(process.cwd(), './packages/uikit/src/icons') },
+      { find: /^@tidbcloud\/uikit\/biz$/, replacement: path.resolve(process.cwd(), './packages/uikit/src/biz') },
+      { find: /^@tidbcloud\/uikit\/utils$/, replacement: path.resolve(process.cwd(), './packages/uikit/src/utils') },
+      { find: /^@tidbcloud\/uikit$/, replacement: path.resolve(process.cwd(), './packages/uikit/src/primitive') }
+    ]
+  }
+})


### PR DESCRIPTION
The aliases are added to resolve paths to specific directories within the uikit package, so the build process can be skipped when editing component code.

Close #122 