### PR TITLE
fix(sb): fix storybook build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,6 +18,9 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: true
+  },
+  typescript: {
+    reactDocgen: false
   }
 }
 

--- a/stories/.eslintrc
+++ b/stories/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+      "file-extension-in-import-ts/file-extension-in-import-ts": "off"
+  }
+}

--- a/stories/uikit/biz/Typography.stories.tsx
+++ b/stories/uikit/biz/Typography.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj, StoryFn } from '@storybook/react'
 import { Stack, Typography, TYPOGRAPHY_STYLES_MAP } from '@tidbcloud/uikit'
 
-import { COLOR_LIST } from '../../constants.js'
+import { COLOR_LIST } from '../../constants'
 
 type Story = StoryObj<typeof Typography>
 


### PR DESCRIPTION
![image](https://github.com/tidbcloud/tidbcloud-uikit/assets/18644268/16da44fb-172d-4c03-97f3-daed10331b4e)

storybook appended some code like below, but the symbol is incorrect, seems like a docgen parsing error.

```
_ActionIcon.__docgenInfo = {
    description: "",
    methods: [],
    displayName: "@mantine/core/ActionIcon"
};
```

worksaround is turn `reactCodegen` to false.

```
typescript: {
	reactDocgen: false
}
```

related:
https://github.com/storybookjs/storybook/issues/25247
https://github.com/storybookjs/storybook/discussions/24032
https://github.com/storybookjs/storybook/discussions/24032


