### PR TITLE
fix(uikit): bundler external optinos

### DIFF
--- a/.changeset/chilly-elephants-shout.md
+++ b/.changeset/chilly-elephants-shout.md
@@ -1,0 +1,5 @@
+---
+'@tidbcloud/uikit': patch
+---
+
+Only include mantine related libs to bundling

--- a/packages/uikit/vite.config.ts
+++ b/packages/uikit/vite.config.ts
@@ -8,8 +8,9 @@ import dts from 'vite-plugin-dts'
 const packageJson = JSON.parse(readFileSync('./package.json', { encoding: 'utf-8' }))
 
 const globals = {
-  // don't include dependencies here, so they will all be bundled
-  // otherwise it might referencing modules in node_moduels and use the original component style
+  // remember to filter out dependencies that depends on mantine, so they will all be bundled
+  // otherwise it might referencing original mantine in node_moduels and use the original component style
+  ...(packageJson?.dependencies || {}),
   ...(packageJson?.peerDependencies || {})
 }
 
@@ -37,7 +38,11 @@ export default defineConfig({
     },
 
     rollupOptions: {
-      external: ['react', 'react-dom', 'lodash-es', ...Object.keys(globals).filter((i) => !i.startsWith('@mantine'))],
+      external: [
+        ...Object.keys(globals).filter((i) => {
+          return !i.startsWith('@mantine') && !['mantine-react-table'].includes(i)
+        })
+      ],
       output: [
         {
           dir: 'dist',


### PR DESCRIPTION
exclude all dependencies is risky, we only exclude needed ones, that is all mantine lib and libs that depends on mantine.