### PR TITLE
feat: remove focus outline-color transparent style for passing VPAT k…

### DIFF
--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -370,8 +370,7 @@ const theme = createTheme({
             },
             '&:hover': {
               color: themeColor(theme, 'carbon', 9)
-            },
-            '&:focus': { outlineColor: 'transparent' }
+            }
           }
         }
       }


### PR DESCRIPTION
去掉了Tabs focus outline-color为transparent的styling，来恢复Tabs在使用tab键focus时的边框可见性。
此举将帮助TiDB Cloud通过VPAT Keyboard的认证。


<img width="511" alt="Screenshot 2024-11-13 at 15 23 26" src="https://github.com/user-attachments/assets/36c2651e-3ad4-41f9-84d3-a90280be9963">
