### PR TITLE
feat(theme): enhance disabled state handling for buttons

### DIFF
--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -241,7 +241,7 @@ const theme = createTheme({
               backgroundColor: bgHoverColor
             },
 
-            '&:disabled': {
+            '&:disabled, &[data-disabled]': {
               color: theme.white,
               backgroundColor: themeColor(theme, color, 5)
             }
@@ -267,7 +267,7 @@ const theme = createTheme({
               backgroundColor: themeColor(theme, color, bgColorShade + 1)
             },
 
-            '&:disabled': {
+            '&:disabled, &[data-disabled]': {
               color: themeColor(theme, color, 6),
               borderColor: themeColor(theme, color, borderColorShade + 1),
               backgroundColor: themeColor(theme, color, 2)
@@ -291,7 +291,7 @@ const theme = createTheme({
               backgroundColor: themeColor(theme, color, bgColorShade + 1)
             },
 
-            '&:disabled': {
+            '&:disabled, &[data-disabled]': {
               color: themeColor(theme, color, 6),
               borderColor: themeColor(theme, color, borderColorShade + 1),
               backgroundColor: themeColor(theme, color, 2)
@@ -313,7 +313,7 @@ const theme = createTheme({
               backgroundColor: themeColor(theme, color, bgColorShade + 1)
             },
 
-            '&:disabled': {
+            '&:disabled, &[data-disabled]': {
               color: themeColor(theme, color, 6)
             }
           }

--- a/stories/uikit/primitive/Button.stories.tsx
+++ b/stories/uikit/primitive/Button.stories.tsx
@@ -241,3 +241,7 @@ export const WithIcon: Story = {
     </Group>
   )
 }
+
+export const DataDisabled: Story = {
+  render: () => <Button data-disabled>With data-disabled</Button>
+}

--- a/stories/uikit/primitive/Tooltip.stories.tsx
+++ b/stories/uikit/primitive/Tooltip.stories.tsx
@@ -63,3 +63,21 @@ export const Primary: Story = {
     }
   }
 }
+
+export const DisabledButton: Story = {
+  render: ({ ...props }) => (
+    <Tooltip {...props} label="Tooltip">
+      <Button disabled>Disabled button</Button>
+    </Tooltip>
+  ),
+  parameters: {
+    docs: {
+      source: {
+        language: 'jsx',
+        code: `<Tooltip label="Tooltip">
+  <Button disabled>Disabled button</Button>
+</Tooltip>`
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Updated theme styles to support both '&:disabled' and '&[data-disabled]' selectors for better consistency in button states.
- Added new story for Button component demonstrating the 'data-disabled' attribute.
- Introduced a new story for Tooltip component showcasing a disabled button within a tooltip context.