### PR TITLE
chore: release @tidbcloud/uikit@2.0.0-beta.96

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -66,6 +66,7 @@
     "orange-experts-rescue",
     "polite-pandas-deliver",
     "poor-pianos-dance",
+    "pretty-singers-grab",
     "proud-shrimps-ring",
     "quiet-flies-protect",
     "rare-forks-suffer",

--- a/.changeset/pretty-singers-grab.md
+++ b/.changeset/pretty-singers-grab.md
@@ -1,0 +1,8 @@
+---
+'@tidbcloud/uikit': patch
+---
+
+- fix(Select): update Select component styles to include check icon and… ([#358](https://github.com/tidbcloud/tidbcloud-uikit/pull/358))
+- fix(Tree): update background color from blue to carbon for indeterminate checkbox for improved theme consistency ([#357](https://github.com/tidbcloud/tidbcloud-uikit/pull/357))
+- fix(PageShell): update PageHeader styles to set height instead of margin ([#356](https://github.com/tidbcloud/tidbcloud-uikit/pull/356))
+- fix(ProTable): resizing cursor missing ([#355](https://github.com/tidbcloud/tidbcloud-uikit/pull/355))

--- a/packages/documentation/CHANGELOG.md
+++ b/packages/documentation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tidbcloud/uikit-documentation
 
+## 0.1.30-beta.96
+
+### Patch Changes
+
+- Updated dependencies
+  - @tidbcloud/uikit@2.0.0-beta.96
+
 ## 0.1.30-beta.95
 
 ### Patch Changes

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidbcloud/uikit-documentation",
-  "version": "0.1.30-beta.95",
+  "version": "0.1.30-beta.96",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/uikit/CHANGELOG.md
+++ b/packages/uikit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @tidbcloud/uikit
 
+## 2.0.0-beta.96
+
+### Patch Changes
+
+- fix(Select): update Select component styles to include check icon and… ([#358](https://github.com/tidbcloud/tidbcloud-uikit/pull/358))
+- fix(Tree): update background color from blue to carbon for indeterminate checkbox for improved theme consistency ([#357](https://github.com/tidbcloud/tidbcloud-uikit/pull/357))
+- fix(PageShell): update PageHeader styles to set height instead of margin ([#356](https://github.com/tidbcloud/tidbcloud-uikit/pull/356))
+- fix(ProTable): resizing cursor missing ([#355](https://github.com/tidbcloud/tidbcloud-uikit/pull/355))
+
 ## 2.0.0-beta.95
 
 ### Patch Changes

--- a/packages/uikit/package.json
+++ b/packages/uikit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidbcloud/uikit",
-  "version": "2.0.0-beta.95",
+  "version": "2.0.0-beta.96",
   "description": "tidbcloud uikit",
   "type": "module",
   "main": "dist/primitive/index.cjs",


### PR DESCRIPTION
- Updated version to 2.0.0-beta.96 in package.json files for both @tidbcloud/uikit and @tidbcloud/uikit-documentation.
- Added new changeset 'pretty-singers-grab' documenting several style fixes:
  - Updated Select component styles to include check icon.
  - Changed Tree component's indeterminate checkbox background color for better theme consistency.
  - Adjusted PageHeader styles in PageShell to set height instead of margin.
  - Fixed missing resizing cursor in ProTable.