### PR TITLE
fix(theme): update Card and Paper components' shadow and border styles

### DIFF
--- a/.changeset/silver-cats-repair.md
+++ b/.changeset/silver-cats-repair.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix(theme): update Card and Paper components' shadow and border styles

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,6 +21,11 @@ const config: StorybookConfig = {
   },
   typescript: {
     reactDocgen: false
+  },
+  core: {
+    disableWhatsNewNotifications: true,
+    disableTelemetry: true,
+    enableCrashReports: false
   }
 }
 

--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -20,7 +20,7 @@ import {
   RadioProps,
   ActionIconProps
 } from '../primitive/index.js'
-import { getPrimaryShade, getThemeColor, rem, rgba } from '../utils/index.js'
+import { getPrimaryShade, getThemeColor, rem } from '../utils/index.js'
 
 import * as dark from './colors.dark.js'
 import * as light from './colors.js'
@@ -814,23 +814,30 @@ const theme = createTheme({
     },
     Card: {
       defaultProps: {
-        shadow: 'xs',
+        shadow: 'none',
         withBorder: true
       },
       styles: (theme: MantineTheme) => {
         return {
           root: {
-            backgroundColor: theme.colors.carbon[0]
+            borderColor: theme.colors.carbon[4]
+          },
+          section: {
+            borderColor: theme.colors.carbon[4]
           }
         }
       }
     },
     Paper: {
+      defaultProps: {
+        shadow: 'none',
+        withBorder: false
+      },
       styles: (theme: MantineTheme, props: PaperProps) => {
         return {
           root: {
             backgroundColor: themeColor(theme, 'carbon', 0),
-            borderColor: props.withBorder ? themeColor(theme, 'carbon', 3) : 'transparent'
+            borderColor: props.withBorder ? themeColor(theme, 'carbon', 4) : 'transparent'
           }
         }
       }

--- a/stories/uikit/primitive/Card.stories.tsx
+++ b/stories/uikit/primitive/Card.stories.tsx
@@ -23,7 +23,7 @@ export default meta
 function Usage() {
   return (
     <div style={{ maxWidth: 400, padding: 40, margin: 'auto' }}>
-      <Card withBorder p="lg">
+      <Card p="lg">
         <Card.Section inheritPadding>Card section 1</Card.Section>
         <Card.Section inheritPadding withBorder>
           Card section 2


### PR DESCRIPTION
- Changed Card default shadow from 'xs' to 'none' and updated border color to carbon[4].
- Updated Paper default props to set shadow to 'none' and withBorder to false, adjusting border color accordingly.