### PR TITLE
chore: add npm setup step for publishing snapshots

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -56,6 +56,9 @@ jobs:
           # GITHUB_TOKEN is automatically available
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup npm for Publishing
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_REGISTRY_TOKEN }}" > .npmrc
+
       - name: Publish Snapshot to npm under experimental tag
         run: pnpm exec changeset publish --tag experimental
         env:


### PR DESCRIPTION
This commit introduces a step to set up npm authentication for publishing snapshots to the npm registry, ensuring the process can access the necessary credentials securely.