### PR TITLE
feat(theme): add default props for HoverCard/Popover

### DIFF
--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -1272,6 +1272,12 @@ const theme = createTheme({
           }
         }
       }
+    },
+    HoverCard: {
+      defaultProps: {
+        withArrow: true,
+        shadow: 'md'
+      }
     }
   }
 })

--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -1278,6 +1278,12 @@ const theme = createTheme({
         withArrow: true,
         shadow: 'md'
       }
+    },
+    Popover: {
+      defaultProps: {
+        withArrow: true,
+        shadow: 'md'
+      }
     }
   }
 })

--- a/stories/uikit/primitive/HoverCard.stories.tsx
+++ b/stories/uikit/primitive/HoverCard.stories.tsx
@@ -65,3 +65,17 @@ export const Primary: Story = {
     }
   }
 }
+
+export function DefaultProps() {
+  return (
+    <HoverCard>
+      <HoverCard.Target>
+        <Button>Hover to reveal the card</Button>
+      </HoverCard.Target>
+      <HoverCard.Dropdown>
+        Hover card is revealed when user hovers over target element, it will be hidden once mouse is not over both
+        target and dropdown elements
+      </HoverCard.Dropdown>
+    </HoverCard>
+  )
+}


### PR DESCRIPTION
- Set default props `withArrow: true` and `shadow: 'md'` in theme.
- Introduced `DefaultProps` story to demonstrate HoverCard functionality.