### PR TITLE
fix(TimePicker): change value types to string and update format handling

### DIFF
--- a/.changeset/sixty-kids-matter.md
+++ b/.changeset/sixty-kids-matter.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix(TimePicker): change value types to string and update format handling

--- a/packages/uikit/src/biz/DateTimePicker/index.tsx
+++ b/packages/uikit/src/biz/DateTimePicker/index.tsx
@@ -244,9 +244,12 @@ export const DateTimePicker = ({
 export interface TimePickerProps
   extends Omit<TimeInputProps, 'value' | 'onChange' | 'defaultValue'>,
     Pick<PopoverProps, 'withinPortal' | 'withArrow' | 'position' | 'shadow'> {
-  defaultValue?: Date
-  value?: Date
-  onChange?: (val: Date) => void
+  defaultValue?: string
+  /**
+   * with format of `HH:mm:ss`
+   */
+  value?: string
+  onChange?: (val: string) => void
   disable?: boolean
   size?: MantineSize
 }
@@ -267,10 +270,10 @@ export const TimePicker = ({
   ...rest
 }: TimePickerProps) => {
   const [currentValue, setCurrentValue] = useUncontrolled({
-    value: value ? dayjs(value) : undefined,
-    defaultValue: defaultValue ? dayjs(defaultValue) : dayjs(),
+    value: value ? dayjs(value, 'HH:mm:ss') : undefined,
+    defaultValue: defaultValue ? dayjs(defaultValue, 'HH:mm:ss') : dayjs(),
     onChange: (v) => {
-      onChange?.(v.toDate())
+      onChange?.(v.format('HH:mm:ss'))
     }
   })
   const [currentValueChangedBy, setCurrentValueChangedBy] = useState<CurrentValueChangedBy | null>(null)

--- a/stories/uikit/biz/TimePicker.stories.tsx
+++ b/stories/uikit/biz/TimePicker.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react'
 import { Stack, Button } from '@tidbcloud/uikit'
 import { TimePicker } from '@tidbcloud/uikit/biz'
+import { dayjs } from '@tidbcloud/uikit/utils'
 import { useState } from 'react'
 
 const decorator = (Story: StoryFn) => {
@@ -18,18 +19,45 @@ const meta: Meta<typeof TimePicker> = {
   parameters: {}
 }
 
-export function Demo() {
-  const [value, setValue] = useState<Date>(new Date())
+export function WithLabel() {
+  return <TimePicker maw={200} label="Input label" description="Input description" />
+}
+
+export function Controlled() {
+  const [value, setValue] = useState<string>('12:00:00')
   return (
     <Stack>
-      <TimePicker value={value} onChange={setValue} minTime="00:00:00" maxTime="23:59:59" />
-      <Button onClick={() => setValue(new Date(Date.now() + Math.random() * 10000000000))}>Set random date</Button>
+      <TimePicker maw={200} value={value} onChange={setValue} minTime="00:00:00" maxTime="23:59:59" />
+      <Button
+        onClick={() =>
+          setValue(
+            dayjs()
+              .add(Math.random() * 10000000000, 'second')
+              .format('HH:mm:ss')
+          )
+        }
+      >
+        Set random time
+      </Button>
     </Stack>
   )
 }
 
 export function Uncontrolled() {
-  return <TimePicker defaultValue={new Date()} onChange={console.log} />
+  return <TimePicker maw={200} defaultValue="12:00:00" onChange={console.log} />
+}
+
+export function Disabled() {
+  return <TimePicker maw={200} disable />
+}
+
+export function Accessibility() {
+  return (
+    <>
+      <p>Set aria-label when used without label prop, so screen reader will read it and not showing any label</p>
+      <TimePicker maw={200} aria-label="My input" />
+    </>
+  )
 }
 
 export default meta


### PR DESCRIPTION
Updated TimePickerProps to accept string values for defaultValue and value, with a format of `HH:mm:ss`. Adjusted internal logic to handle string values using dayjs for parsing and formatting. Enhanced stories to reflect these changes, including a new Controlled example with random time setting.