### PR TITLE
refactor(biz/app-shell): extract back button props for cleaner prop handling

### DIFF
--- a/.changeset/thirty-penguins-peel.md
+++ b/.changeset/thirty-penguins-peel.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+refactor(biz/app-shell): extract back button props for cleaner prop handling

--- a/packages/uikit/src/biz/AppShell/AppPageShell.tsx
+++ b/packages/uikit/src/biz/AppShell/AppPageShell.tsx
@@ -64,6 +64,8 @@ export const AppPageShell = ({
     )
   }
 
+  const { withBack, onBackClick, ...headerPropsWithoutBack } = headerProps ?? {}
+
   return (
     <PageShellBaseRoot
       {...wrapperProps}
@@ -83,11 +85,11 @@ export const AppPageShell = ({
       ])}
     >
       <PageShellBaseHeader
-        {...headerProps}
+        {...headerPropsWithoutBack}
         leftSection={
           <Group wrap="nowrap" gap={0}>
             <ExpandNavbarButtonPlaceholder />
-            {headerProps?.withBack && <PageShellBaseBackButton onClick={headerProps?.onBackClick} mr="md" />}
+            {withBack && <PageShellBaseBackButton onClick={onBackClick} mr="md" />}
           </Group>
         }
         sx={mergeSxList([


### PR DESCRIPTION
This PR extracts `withBack` and `onBackClick` from `headerProps` to avoid prop conflicts and improve code clarity. This ensures that back button specific props are handled separately from other header props passed to `PageShellBaseHeader`.

**✨ Changes:**
- 🔄 Extract back button props using destructuring
- 🧹 Pass clean `headerPropsWithoutBack` to avoid prop pollution  
- 🎯 Use extracted variables directly instead of optional chaining
