### PR TITLE
fix(biz): add horizontal scroll support to AppPageShell

### DIFF
--- a/.changeset/four-seas-nail.md
+++ b/.changeset/four-seas-nail.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix(biz): add horizontal scroll support to AppPageShell

--- a/packages/uikit/src/biz/AppShell/AppPageShell.tsx
+++ b/packages/uikit/src/biz/AppShell/AppPageShell.tsx
@@ -54,7 +54,8 @@ export const AppPageShell = ({
             height: '100%',
             maxWidth: `min(100%, ${maxWidth})`,
             margin: '0 auto',
-            padding: 24
+            padding: 24,
+            overflow: 'auto'
           },
           bodyProps?.sx
         ])}
@@ -79,7 +80,8 @@ export const AppPageShell = ({
           height: '100%',
           maxWidth: `min(100%, ${maxWidth})`,
           margin: '0 auto',
-          minWidth: `calc(${theme.breakpoints.md} - var(--app-shell-navbar-offset))`
+          minWidth: `calc(${theme.breakpoints.md} - var(--app-shell-navbar-offset))`,
+          overflow: 'auto'
         }),
         wrapperProps?.sx
       ])}

--- a/packages/uikit/src/biz/AppShell/AppPageShell.tsx
+++ b/packages/uikit/src/biz/AppShell/AppPageShell.tsx
@@ -55,7 +55,7 @@ export const AppPageShell = ({
             maxWidth: `min(100%, ${maxWidth})`,
             margin: '0 auto',
             padding: 24,
-            overflow: 'auto'
+            overflowX: 'auto'
           },
           bodyProps?.sx
         ])}
@@ -81,7 +81,7 @@ export const AppPageShell = ({
           maxWidth: `min(100%, ${maxWidth})`,
           margin: '0 auto',
           minWidth: `calc(${theme.breakpoints.md} - var(--app-shell-navbar-offset))`,
-          overflow: 'auto'
+          overflowX: 'auto'
         }),
         wrapperProps?.sx
       ])}


### PR DESCRIPTION
## What
Add `overflowX: 'auto'` to AppPageShell container styles to enable horizontal scrolling when content overflows.

## Why
- Prevents content from being cut off when the container width is insufficient
- Improves user experience by allowing horizontal navigation of wide content
- Ensures responsive behavior across different screen sizes

## Changes
- Added `overflowX: 'auto'` to both conditional style branches in AppPageShell component
- Maintains existing responsive behavior while adding overflow handling

## Testing
- [x] Verified horizontal scroll appears when content exceeds container width
- [x] Confirmed no visual regression on normal content
- [x] Tested across different breakpoints