### PR TITLE
fix(biz): enhance DateTimePicker with formatter prop and update storybook demo

### DIFF
--- a/.changeset/eleven-oranges-march.md
+++ b/.changeset/eleven-oranges-march.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix(biz): enhance DateTimePicker with formatter prop and update storybook demo

--- a/packages/uikit/src/biz/DateTimePicker/index.tsx
+++ b/packages/uikit/src/biz/DateTimePicker/index.tsx
@@ -5,30 +5,47 @@ import { useDisclosure, useUncontrolled } from '../../hooks/index.js'
 import { IconClock } from '../../icons/index.js'
 import {
   Box,
+  DatePicker,
   Divider,
   Flex,
   Group,
   Loader,
+  MantineSize,
   Popover,
+  PopoverProps,
   Stack,
   TextInput,
-  Typography,
-  MantineSize,
-  TimeInput,
   TextInputProps,
-  DatePicker,
+  TimeInput,
   TimeInputProps,
-  PopoverProps
+  Typography
 } from '../../primitive/index.js'
 import { dayjs, type Dayjs } from '../../utils/dayjs.js'
 import { DEFAULT_TIME_FORMAT } from '../TimeRangePicker/helpers.js'
 
-import { TimeScollerPicker, CurrentValueChangedBy } from './TimeScollerPicker.js'
+import { CurrentValueChangedBy, TimeScollerPicker } from './TimeScollerPicker.js'
 
 export interface DateTimePickerProps extends Omit<TextInputProps, 'value' | 'onChange' | 'defaultValue'> {
+  /**
+   * The placeholder of the input.
+   * @default 'Select time'
+   */
   placeholder?: string
+  /**
+   * The format of the date string.
+   * @default 'YYYY-MM-DD HH:mm:ss'
+   */
   format?: string
+  /**
+   * A function to format the date in the input
+   * If provided, `format` prop will be ignored.
+   */
+  formatter?: (val: Date) => string
 
+  /**
+   * The UTC offset in minutes.
+   * See https://day.js.org/docs/en/manipulate/utc-offset
+   */
   utcOffset?: number
   defaultValue?: Date
   value?: Date
@@ -45,6 +62,7 @@ export interface DateTimePickerProps extends Omit<TextInputProps, 'value' | 'onC
 export const DateTimePicker = ({
   placeholder = 'Select time',
   format = DEFAULT_TIME_FORMAT,
+  formatter,
   defaultValue,
   value,
   startDate = dayjs().subtract(10, 'year').toDate(),
@@ -91,7 +109,9 @@ export const DateTimePicker = ({
     }, 20)
   })
 
-  const inputStr = currentValue.format(format)
+  const inputStr = formatter
+    ? formatter(currentValue.utcOffset(utcOffset).toDate())
+    : currentValue.utcOffset(utcOffset).format(format)
 
   const utcStr = useMemo(() => {
     const h = Math.floor(utcOffset / 60)

--- a/stories/uikit/biz/DateTimePicker.stories.tsx
+++ b/stories/uikit/biz/DateTimePicker.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react'
-import { Stack, Button } from '@tidbcloud/uikit'
+import { Button, Stack } from '@tidbcloud/uikit'
 import { DateTimePicker } from '@tidbcloud/uikit/biz'
 import { useState } from 'react'
 
@@ -25,7 +25,14 @@ export function Demo() {
   const [value, setValue] = useState<Date>(new Date())
   return (
     <Stack>
-      <DateTimePicker value={value} onChange={setValue} startDate={startDate} endDate={endDate} />
+      <DateTimePicker
+        value={value}
+        onChange={setValue}
+        utcOffset={-7 * 60}
+        startDate={startDate}
+        endDate={endDate}
+        formatter={(val) => val.toISOString()}
+      />
       <Button onClick={() => setValue(new Date(Date.now() + Math.random() * 10000000000))}>Set random date</Button>
     </Stack>
   )


### PR DESCRIPTION
- Added `formatter` prop to `DateTimePicker` for custom date formatting.
- Updated input string logic to utilize the `formatter` if provided.
- Adjusted storybook demo to include `utcOffset` and updated format string.