### PR TITLE
feat(AppShell): add headerLeftSection prop and make aboveMenu optional

### DIFF
--- a/.changeset/hot-feet-kneel.md
+++ b/.changeset/hot-feet-kneel.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+feat(AppShell): add headerLeftSection prop and make aboveMenu optional

--- a/packages/uikit/src/biz/AppShell/AppShell.tsx
+++ b/packages/uikit/src/biz/AppShell/AppShell.tsx
@@ -37,9 +37,6 @@ interface AppShellProps {
      */
     headerLeftSection?: React.ReactNode
     /**
-     * The right section of the navbar header
-     */
-    /**
      * Custom content rendered in the navbar section between the header and the main menu.
      */
     aboveMenu?: React.ReactNode

--- a/packages/uikit/src/biz/AppShell/AppShell.tsx
+++ b/packages/uikit/src/biz/AppShell/AppShell.tsx
@@ -31,9 +31,18 @@ interface AppShellProps {
      */
     logo: React.ReactNode
     /**
+     * The left section of the navbar header, which is usually the logo
+     * If not provided, the logo will be used as the left section
+     * @default undefined
+     */
+    headerLeftSection?: React.ReactNode
+    /**
+     * The right section of the navbar header
+     */
+    /**
      * Custom content rendered in the navbar section between the header and the main menu.
      */
-    aboveMenu: React.ReactNode
+    aboveMenu?: React.ReactNode
     /**
      * The footer section of the navbar
      */
@@ -99,18 +108,20 @@ export const AppShell = ({ banner, navbar, children }: React.PropsWithChildren<A
         <Navbar withBorder hidden={navbarCollapsed}>
           <NavbarSection>
             <NavbarHeader
-              logo={navbar.logo}
+              logo={navbar.headerLeftSection || navbar.logo}
               onLogoClick={navbar.onLogoClick}
               onToggleCollapse={handleNavbarCollapse}
               px="md"
               py={8}
             />
           </NavbarSection>
-          <NavbarSection>
-            <Box className="tiui-app-shell-navbar-above-menu" px="md">
-              {navbar.aboveMenu}
-            </Box>
-          </NavbarSection>
+          {navbar.aboveMenu && (
+            <NavbarSection>
+              <Box className="tiui-app-shell-navbar-above-menu" px="md">
+                {navbar.aboveMenu}
+              </Box>
+            </NavbarSection>
+          )}
           <NavbarSection className="tiui-app-shell-navbar-menu-section" grow scrollable py={8}>
             <Stack ref={navMenuRef} className="tiui-app-shell-navbar-menu" gap={8} px="md" />
           </NavbarSection>


### PR DESCRIPTION
## Changes

This PR enhances the `AppShell` component's navbar customization capabilities:

### 🚀 New Features
- **Added `headerLeftSection` prop**: Allows customization of the navbar header's left section content
  - If not provided, falls back to the existing `logo` prop
  - Provides more flexibility for header layout customization

### 🔧 Improvements  
- **Made `aboveMenu` prop optional**: The `aboveMenu` section is now conditionally rendered only when content is provided
  - Reduces unnecessary DOM elements when no above-menu content is needed
  - Maintains backward compatibility with existing implementations

### 📝 Documentation
- Added comprehensive JSDoc comments for the new `headerLeftSection` prop
- Updated type definitions to reflect the optional nature of `aboveMenu`

### 🔄 Implementation Details
- The navbar header now uses `navbar.headerLeftSection || navbar.logo` for the logo prop
- Added conditional rendering with `{navbar.aboveMenu && (...)}`  for the above-menu section
- All existing functionality remains unchanged, ensuring backward compatibility

## Breaking Changes
None - this is a backward-compatible enhancement.

## Testing
- ✅ Existing AppShell usage continues to work without changes
- ✅ New `headerLeftSection` prop works as expected
- ✅ Optional `aboveMenu` prop renders conditionally