### PR TITLE
 feat(ProMultiSelect): support `sx` and `size` props

### DIFF
--- a/.changeset/beige-ducks-tickle.md
+++ b/.changeset/beige-ducks-tickle.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+ feat(ProMultiSelect): support `sx` and `size` props

--- a/packages/uikit/src/biz/ProMultiSelect/index.tsx
+++ b/packages/uikit/src/biz/ProMultiSelect/index.tsx
@@ -123,6 +123,7 @@ export interface ProMultiSelectProps
     | 'onSearchChange'
     | 'onRemove'
     | 'onClear'
+    | 'sx'
   > {
   loading?: boolean
   allowSelectAll?: boolean
@@ -274,6 +275,7 @@ export const ProMultiSelect: React.FC<ProMultiSelectProps> = (_props) => {
     error,
     allowSelectAll,
     selectAllText,
+    sx,
     onOptionSubmit,
     renderOption,
     filter,
@@ -469,6 +471,8 @@ export const ProMultiSelect: React.FC<ProMultiSelectProps> = (_props) => {
         <InputBase
           error={error}
           w={width}
+          sx={sx}
+          size={size}
           component="button"
           type="button"
           pointer

--- a/stories/uikit/biz/ProMultiSelect.stories.tsx
+++ b/stories/uikit/biz/ProMultiSelect.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta, StoryObj, StoryFn } from '@storybook/react'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react'
+import { Group } from '@tidbcloud/uikit'
 import { ProMultiSelect } from '@tidbcloud/uikit/biz'
 
 type Story = StoryObj<typeof ProMultiSelect>
@@ -26,6 +27,12 @@ export const Primary: Story = {
   parameters: {
     controls: { expanded: true }
   },
+  argTypes: {
+    size: {
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      control: { type: 'select' }
+    }
+  },
   args: {
     label: 'ProMultiSelect',
     searchable: true,
@@ -37,6 +44,7 @@ export const Primary: Story = {
     width: 330,
     placeholder: 'Select items',
     allowSelectAll: true,
+    size: 'md',
     data: [
       'Apples',
       'Cookie',
@@ -48,4 +56,23 @@ export const Primary: Story = {
       'Traditional Beef Wellington with Mushroom Duxelles'
     ]
   }
+}
+
+export function WithSx() {
+  return (
+    <Group>
+      <ProMultiSelect
+        label="ProMultiSelect"
+        searchable={true}
+        clearable={true}
+        loading={false}
+        disabled={false}
+        sx={{
+          flex: 1
+        }}
+      />
+
+      <div style={{ color: 'red' }}>placeholder</div>
+    </Group>
+  )
 }


### PR DESCRIPTION
This pull request enhances the `ProMultiSelect` component by adding support for the `sx` prop, enabling consumers to apply custom styles directly. It also ensures the `size` prop is correctly passed to the underlying `InputBase` component.

### Changes

- Added the `sx` prop to `ProMultiSelectProps` and passed it to the `InputBase` component.
- Ensured the `size` prop is passed down to the `InputBase` for consistent sizing.
- Updated the Storybook story to include a control for the `size` prop.
- Added a new story, `WithSx`, to demonstrate how to use the `sx` prop for flexible layout adjustments.