### PR TITLE
fix(TimeRangePicker): adjust padding and width for input components in AbsoluteTimeRangePicker

### DIFF
--- a/.changeset/fast-clouds-give.md
+++ b/.changeset/fast-clouds-give.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix(TimeRangePicker): adjust padding and width for input components in AbsoluteTimeRangePicker

--- a/packages/uikit/src/biz/TimeRangePicker/AbsoluteTimeRangePicker.tsx
+++ b/packages/uikit/src/biz/TimeRangePicker/AbsoluteTimeRangePicker.tsx
@@ -122,9 +122,9 @@ const AbsoluteTimeRangePicker = ({
       <Group gap={0} pt={8} justify="space-between">
         <Typography variant="label-sm">{localization?.start || 'Start'}</Typography>
         <Group gap={8}>
-          <Input w={116} value={startDate} error={beyondMin || startAfterEnd || beyondDuration} />
+          <Input w={110} value={startDate} error={beyondMin || startAfterEnd || beyondDuration} />
           <TimeInput
-            w={110}
+            w={116}
             withSeconds
             value={startTime}
             onChange={(d) => updateTime(d.currentTarget.value, setStart)}
@@ -136,9 +136,9 @@ const AbsoluteTimeRangePicker = ({
       <Group gap={0} pt={8} justify="space-between">
         <Typography variant="label-sm">{localization?.end || 'End'}</Typography>
         <Group gap={8}>
-          <Input w={116} value={endDate} error={beyondMax || startAfterEnd || beyondDuration} />
+          <Input w={110} value={endDate} error={beyondMax || startAfterEnd || beyondDuration} />
           <TimeInput
-            w={110}
+            w={116}
             withSeconds
             value={endTime}
             onChange={(d) => updateTime(d.currentTarget.value, setEnd)}

--- a/packages/uikit/src/biz/TimeRangePicker/AbsoluteTimeRangePicker.tsx
+++ b/packages/uikit/src/biz/TimeRangePicker/AbsoluteTimeRangePicker.tsx
@@ -113,7 +113,7 @@ const AbsoluteTimeRangePicker = ({
   const apply = () => onChange?.({ type: 'absolute', value: [dayjs(start).unix(), dayjs(end).unix()] })
 
   return (
-    <Box p="md" w={280} m={-4}>
+    <Box p={8} pt="md" w={280} m={-4}>
       <Group pb="xs" mt={-4} onClick={onReturnClick} sx={{ cursor: 'pointer' }}>
         <IconChevronLeft size={16} />
         <Typography variant="body-lg">{localization?.back || 'Back'}</Typography>
@@ -124,7 +124,7 @@ const AbsoluteTimeRangePicker = ({
         <Group gap={8}>
           <Input w={116} value={startDate} error={beyondMin || startAfterEnd || beyondDuration} />
           <TimeInput
-            w={90}
+            w={110}
             withSeconds
             value={startTime}
             onChange={(d) => updateTime(d.currentTarget.value, setStart)}
@@ -138,7 +138,7 @@ const AbsoluteTimeRangePicker = ({
         <Group gap={8}>
           <Input w={116} value={endDate} error={beyondMax || startAfterEnd || beyondDuration} />
           <TimeInput
-            w={90}
+            w={110}
             withSeconds
             value={endTime}
             onChange={(d) => updateTime(d.currentTarget.value, setEnd)}

--- a/packages/uikit/src/biz/TimeRangePicker/AbsoluteTimeRangePicker.tsx
+++ b/packages/uikit/src/biz/TimeRangePicker/AbsoluteTimeRangePicker.tsx
@@ -122,9 +122,9 @@ const AbsoluteTimeRangePicker = ({
       <Group gap={0} pt={8} justify="space-between">
         <Typography variant="label-sm">{localization?.start || 'Start'}</Typography>
         <Group gap={8}>
-          <Input w={110} value={startDate} error={beyondMin || startAfterEnd || beyondDuration} />
+          <Input w={116} value={startDate} error={beyondMin || startAfterEnd || beyondDuration} />
           <TimeInput
-            w={116}
+            w={110}
             withSeconds
             value={startTime}
             onChange={(d) => updateTime(d.currentTarget.value, setStart)}
@@ -136,9 +136,9 @@ const AbsoluteTimeRangePicker = ({
       <Group gap={0} pt={8} justify="space-between">
         <Typography variant="label-sm">{localization?.end || 'End'}</Typography>
         <Group gap={8}>
-          <Input w={110} value={endDate} error={beyondMax || startAfterEnd || beyondDuration} />
+          <Input w={116} value={endDate} error={beyondMax || startAfterEnd || beyondDuration} />
           <TimeInput
-            w={116}
+            w={110}
             withSeconds
             value={endTime}
             onChange={(d) => updateTime(d.currentTarget.value, setEnd)}


### PR DESCRIPTION
input type=time may use either a 24-hour or a 12-hour format, depending on the user's setting, so it needs to be handled accordingly for compatibility.
![image](https://github.com/user-attachments/assets/2129f5b7-284c-4d19-bf7a-79719f81df21)
![image](https://github.com/user-attachments/assets/76a8e8f6-84b7-48db-8958-e85e3ee0dd49)

