### PR TITLE
feat(TagsInput): add size support and styles to theme configuration

### DIFF
--- a/.changeset/perfect-ads-applaud.md
+++ b/.changeset/perfect-ads-applaud.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix(TagsInput): correct size support and styles to theme configuration

--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_THEME,
   MantineTheme,
   RadioIndicatorProps,
+  TagsInputProps,
   createTheme,
   mergeMantineTheme
 } from '@mantine/core'
@@ -68,6 +69,12 @@ function getInputStyles(theme: MantineTheme, props: Pick<InputProps, 'size' | 'v
         '--input-fz': `${inputFontSize}px`
       }
     : {}
+
+  const withInputSize = {
+    '&:not(.mantine-Textarea-input)': {
+      ...inputSize
+    }
+  }
   const passwordInnerInputSize = size
     ? {
         height: size - 2,
@@ -80,9 +87,7 @@ function getInputStyles(theme: MantineTheme, props: Pick<InputProps, 'size' | 'v
   if (props.variant === 'unstyled') {
     return {
       input: {
-        '&:not(.mantine-Textarea-input)': {
-          ...inputSize
-        },
+        ...withInputSize,
         '& .mantine-PasswordInput-innerInput': {
           ...passwordInnerInputSize
         },
@@ -98,9 +103,7 @@ function getInputStyles(theme: MantineTheme, props: Pick<InputProps, 'size' | 'v
       input: {
         '--input-bg': themeColor(theme, 'carbon', 3),
         '--input-bd-focus': themeColor(theme, 'carbon', 9),
-        '&:not(.mantine-Textarea-input)': {
-          ...inputSize
-        },
+        ...withInputSize,
         '& .mantine-PasswordInput-innerInput': {
           ...passwordInnerInputSize
         },
@@ -127,9 +130,7 @@ function getInputStyles(theme: MantineTheme, props: Pick<InputProps, 'size' | 'v
       border: `1px solid ${themeColor(theme, 'carbon', 4)}`,
       backgroundColor: themeColor(theme, 'carbon', 0),
 
-      '&:not(.mantine-Textarea-input)': {
-        ...inputSize
-      },
+      ...withInputSize,
 
       '&:hover': {
         borderColor: themeColor(theme, 'carbon', 5)
@@ -767,6 +768,27 @@ const theme = createTheme({
     },
     Textarea: {
       styles: getInputStyles
+    },
+    TagsInput: {
+      styles: (theme: MantineTheme, props: TagsInputProps) => {
+        const size = InputSizes[(props.size as keyof typeof InputSizes) ?? 'md']
+        // 2px is the border width
+        const inputSize = `calc(${size}px - 2 * var(--input-padding-y, 0rem) - 2px)`
+        return {
+          input: {
+            height: 'auto'
+          },
+          inputField: {
+            height: inputSize
+          },
+          pill: {
+            height: inputSize,
+            '& .mantine-Pill-label': {
+              lineHeight: inputSize
+            }
+          }
+        }
+      }
     },
     Badge: {
       defaultProps: {

--- a/stories/uikit/primitive/TagsInput.stories.tsx
+++ b/stories/uikit/primitive/TagsInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react'
-import { TagsInput } from '@tidbcloud/uikit'
+import { Stack, TagsInput } from '@tidbcloud/uikit'
 import { useState } from 'react'
 
 const decorator = (Story: StoryFn) => {
@@ -46,5 +46,17 @@ export function MaxSelectedValues() {
       maxTags={3}
       defaultValue={['first', 'second']}
     />
+  )
+}
+
+export function Sizes() {
+  return (
+    <Stack>
+      <TagsInput label="XS" placeholder="Enter tag" size="xs" />
+      <TagsInput label="Small" placeholder="Enter tag" size="sm" />
+      <TagsInput label="Medium" placeholder="Enter tag" size="md" />
+      <TagsInput label="Large" placeholder="Enter tag" size="lg" />
+      <TagsInput label="X-Large" placeholder="Enter tag" size="xl" />
+    </Stack>
   )
 }


### PR DESCRIPTION
- Implemented size variations for TagsInput component in theme.
- Added new styles for input and pill elements based on size prop.
- Updated TagsInput stories to showcase different sizes.