### PR TITLE
feat(DateTimePicker): add footer prop for custom content in DateTimePicker

### DIFF
--- a/packages/uikit/src/biz/DateTimePicker/index.tsx
+++ b/packages/uikit/src/biz/DateTimePicker/index.tsx
@@ -17,8 +17,7 @@ import {
   TextInput,
   TextInputProps,
   TimeInput,
-  TimeInputProps,
-  Typography
+  TimeInputProps
 } from '../../primitive/index.js'
 import { dayjs, type Dayjs } from '../../utils/dayjs.js'
 import { DEFAULT_TIME_FORMAT } from '../TimeRangePicker/helpers.js'
@@ -57,6 +56,7 @@ export interface DateTimePickerProps extends Omit<TextInputProps, 'value' | 'onC
   withinPortal?: boolean
   loading?: boolean
   size?: MantineSize
+  footer?: React.ReactNode
 }
 
 export const DateTimePicker = ({
@@ -72,7 +72,8 @@ export const DateTimePicker = ({
   withinPortal = true,
   sx,
   loading = false,
-  size
+  size,
+  footer
 }: DateTimePickerProps) => {
   const [opened, { close, open }] = useDisclosure(false)
   const [currentValue, setCurrentValue] = useUncontrolled({
@@ -241,15 +242,12 @@ export const DateTimePicker = ({
               </Box>
             </Stack>
           </Group>
-          <Divider mx={-16} />
-          <Group>
-            <Typography size="sm">
-              Time selection in local time zone:{' '}
-              <Typography fw={600} component="span">
-                {utcStr}
-              </Typography>
-            </Typography>
-          </Group>
+          {footer && (
+            <>
+              <Divider mx={-16} />
+              {footer}
+            </>
+          )}
         </Stack>
       </Popover.Dropdown>
     </Popover>

--- a/stories/uikit/biz/DateTimePicker.stories.tsx
+++ b/stories/uikit/biz/DateTimePicker.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react'
-import { Button, Stack } from '@tidbcloud/uikit'
+import { Button, Stack, Typography } from '@tidbcloud/uikit'
 import { DateTimePicker } from '@tidbcloud/uikit/biz'
 import { dayjs } from '@tidbcloud/uikit/utils'
 import { useState } from 'react'
@@ -35,6 +35,17 @@ export function Demo() {
           dayjs(val)
             .utcOffset(-7 * 60)
             .format('YYYY-MM-DD HH:mm:ss Z')
+        }
+        footer={
+          <Stack gap={4}>
+            <Typography size="sm">Local time: {dayjs(value).format('YYYY-MM-DD HH:mm:ss Z')}</Typography>
+            <Typography size="sm">
+              Orgnization time:{' '}
+              {dayjs(value)
+                .utcOffset(60 * -7)
+                .format('YYYY-MM-DD HH:mm:ss Z')}
+            </Typography>
+          </Stack>
         }
       />
       <Button onClick={() => setValue(new Date(Date.now() + Math.random() * 10000000000))}>Set random date</Button>


### PR DESCRIPTION
- Introduced `footer` prop to allow custom content rendering.
- Updated component to conditionally render footer with a Divider.
- Enhanced story to demonstrate footer usage with local and organization time display.