### PR TITLE
feat: update CollapsibleCard for improved state management

### DIFF
--- a/.changeset/orange-islands-play.md
+++ b/.changeset/orange-islands-play.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+feat: Update CollapsibleCard for improved state management

--- a/packages/uikit/src/biz/CollapsibleCard/index.tsx
+++ b/packages/uikit/src/biz/CollapsibleCard/index.tsx
@@ -1,34 +1,49 @@
-import { useDisclosure } from '../../hooks/index.js'
+import { useUncontrolled } from '../../hooks/index.js'
 import { IconChevronRight } from '../../icons/index.js'
 import { Box, BoxProps, Card, CardProps, Collapse, Group, GroupProps } from '../../primitive/index.js'
 
-export interface CollapsibleCardProps extends CardProps {
+export interface CollapsibleCardProps extends Omit<CardProps, 'onChange'> {
   title: React.ReactNode
   children: React.ReactNode
+  opened?: boolean
   defaultOpened?: boolean
   headerProps?: GroupProps
   contentProps?: BoxProps
+  onToggle?: (opened: boolean) => void
+  onTransitionEnd?: (opened: boolean) => void
 }
 
 export const CollapsibleCard = ({
   children,
   title,
+  opened,
   defaultOpened = false,
   headerProps,
-  contentProps
+  contentProps,
+  onToggle,
+  onTransitionEnd
 }: CollapsibleCardProps) => {
-  const [opened, { toggle }] = useDisclosure(defaultOpened)
+  const [finalOpened, setOpened] = useUncontrolled({
+    value: opened,
+    defaultValue: defaultOpened,
+    finalValue: false,
+    onChange: onToggle
+  })
+
+  const handleToggle = () => {
+    setOpened(!finalOpened)
+  }
 
   return (
     <Card>
       <Card.Section>
         <Group
-          onClick={toggle}
+          onClick={handleToggle}
           align="center"
           sx={{
             cursor: 'pointer',
             userSelect: 'none',
-            borderBottom: opened ? '1px solid var(--mantine-color-carbon-3)' : undefined
+            borderBottom: finalOpened ? '1px solid var(--mantine-color-carbon-3)' : undefined
           }}
           p={16}
           bg="carbon.2"
@@ -37,7 +52,7 @@ export const CollapsibleCard = ({
           <IconChevronRight
             size={18}
             sx={{
-              transform: opened ? 'rotate(90deg)' : 'rotate(0deg)',
+              transform: finalOpened ? 'rotate(90deg)' : 'rotate(0deg)',
               transition: 'transform 200ms ease'
             }}
           />
@@ -47,7 +62,7 @@ export const CollapsibleCard = ({
       </Card.Section>
 
       <Card.Section>
-        <Collapse in={opened}>
+        <Collapse in={finalOpened} onTransitionEnd={onTransitionEnd ? () => onTransitionEnd(finalOpened) : undefined}>
           <Box p={16} {...contentProps}>
             {children}
           </Box>

--- a/stories/uikit/biz/CollapsibleCard.stories.tsx
+++ b/stories/uikit/biz/CollapsibleCard.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react'
-import { Box, Button, Group, Stack, Typography } from '@tidbcloud/uikit'
+import { Button, Group, Stack, Typography } from '@tidbcloud/uikit'
 import { CollapsibleCard } from '@tidbcloud/uikit/biz'
 
 type Story = StoryObj<typeof CollapsibleCard>
@@ -45,6 +45,7 @@ export const Primary: Story = {
     return (
       <Stack>
         <CollapsibleCard
+          onTransitionEnd={(opened) => console.log('Transition ended with opened', opened)}
           title={
             <Group>
               <Typography>click title to toggle card</Typography>


### PR DESCRIPTION
Refactor CollapsibleCard to utilize `useUncontrolled` for better state handling and introduce an `onTransitionEnd` prop for transition callbacks.