### PR TITLE
feat: add footer prop to TimeRangePicker for customizable content

### DIFF
--- a/.changeset/thin-colts-swim.md
+++ b/.changeset/thin-colts-swim.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+feat: add footer prop to TimeRangePicker for customizable content

--- a/packages/uikit/src/biz/TimeRangePicker/index.tsx
+++ b/packages/uikit/src/biz/TimeRangePicker/index.tsx
@@ -12,7 +12,8 @@ import {
   Typography,
   ButtonProps,
   ActionIcon,
-  DatePickerProps
+  DatePickerProps,
+  Divider
 } from '../../primitive/index.js'
 
 import AbsoluteTimeRangePicker, { Localization } from './AbsoluteTimeRangePicker.js'
@@ -39,6 +40,7 @@ export interface TimeRangePickerBaseProps extends ButtonProps {
   clearable?: boolean
   relativeFormatter?: (relativeRange: RelativeTimeRange) => string
   absoluteFormatter?: (absoluteRange: AbsoluteTimeRange) => string
+  footer?: React.ReactNode
 
   minDateTime?: () => Date
   maxDateTime?: () => Date
@@ -82,7 +84,8 @@ export const TimeRangePicker = ({
   datePickerProps,
   localization,
   relativeFormatter,
-  absoluteFormatter
+  absoluteFormatter,
+  footer
 }: React.PropsWithChildren<TimeRangePickerProps>) => {
   const [opened, setOpened] = useState(false)
   const [customMode, setCustomMode] = useState(false)
@@ -269,6 +272,13 @@ export const TimeRangePicker = ({
                 )
               })}
             </>
+          </>
+        )}
+
+        {footer && (
+          <>
+            <Divider mx={-4} mt={4} />
+            {footer}
           </>
         )}
       </Menu.Dropdown>

--- a/stories/uikit/biz/TimeRangePicker.stories.tsx
+++ b/stories/uikit/biz/TimeRangePicker.stories.tsx
@@ -1,6 +1,7 @@
 import 'dayjs/locale/zh'
 
 import type { Meta, StoryObj, StoryFn } from '@storybook/react'
+import { Typography } from '@tidbcloud/uikit'
 import { AbsoluteTimeRange, RelativeTimeRange, TimeRangePicker, TimeRangePickerProps } from '@tidbcloud/uikit/biz'
 import { dayjs } from '@tidbcloud/uikit/utils'
 import duration from 'dayjs/plugin/duration'
@@ -39,7 +40,12 @@ export default meta
 // More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
 export const Basic: Story = {
   args: {
-    value: { type: 'relative', value: 30 * 60 }
+    value: { type: 'relative', value: 30 * 60 },
+    footer: (
+      <Typography c="carbon.7" px={14} pt={8} pb={6} fz="xs">
+        Current used is org time zone: UTC+08:00
+      </Typography>
+    )
   }
 }
 


### PR DESCRIPTION
- Introduced a new `footer` prop to the TimeRangePicker component, allowing users to pass custom content.
- Updated the component to render a Divider above the footer if provided.
- Modified the TimeRangePicker story to demonstrate the new footer functionality.
<img width="778" height="1040" alt="image" src="https://github.com/user-attachments/assets/ace4a3d5-383f-484e-a344-5bfaa1905c48" />
<img width="712" height="1198" alt="image" src="https://github.com/user-attachments/assets/51df73e4-ec88-4092-9881-c9ad8ef6ff38" />
