### PR TITLE
fix: correct organization time calculation in DateTimePicker demo

### DIFF
--- a/stories/uikit/biz/DateTimePicker.stories.tsx
+++ b/stories/uikit/biz/DateTimePicker.stories.tsx
@@ -51,10 +51,7 @@ export function Demo() {
           <Stack gap={4}>
             <Typography size="sm">Local time: {dayjs(value).format('YYYY-MM-DD HH:mm:ss Z')}</Typography>
             <Typography size="sm">
-              Orgnization time:{' '}
-              {dayjs(value)
-                .utcOffset(60 * -7)
-                .format('YYYY-MM-DD HH:mm:ss Z')}
+              Orgnization time: {dayjs(value).utcOffset(utcOffset).format('YYYY-MM-DD HH:mm:ss Z')}
             </Typography>
           </Stack>
         }


### PR DESCRIPTION
## Summary

This pull request corrects the organization time calculation in the DateTimePicker demo.

## Changes

- Updated the organization time calculation to use a dynamic UTC offset instead of a hardcoded value.