### PR TITLE
feat: enhance FormSegmentedControl to support external onChange handler

### DIFF
--- a/.changeset/curvy-toes-float.md
+++ b/.changeset/curvy-toes-float.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+feat: enhance FormSegmentedControl to support external onChange handler

--- a/packages/uikit/src/biz/Form/SegmentControl.tsx
+++ b/packages/uikit/src/biz/Form/SegmentControl.tsx
@@ -7,7 +7,12 @@ export interface FormSegmentedControlProps extends SegmentedControlProps {
   rules?: RegisterOptions
 }
 
-export const FormSegmentedControl = ({ name, rules, ...restProps }: FormSegmentedControlProps) => {
+export const FormSegmentedControl = ({
+  name,
+  rules,
+  onChange: formOnChange,
+  ...restProps
+}: FormSegmentedControlProps) => {
   const { control } = useFormContext()
 
   return (
@@ -16,7 +21,16 @@ export const FormSegmentedControl = ({ name, rules, ...restProps }: FormSegmente
       control={control}
       rules={rules}
       render={({ field: { onChange, value } }) => {
-        return <SegmentedControl value={value} onChange={onChange} {...restProps} />
+        return (
+          <SegmentedControl
+            value={value}
+            onChange={(val) => {
+              onChange(val)
+              formOnChange?.(val)
+            }}
+            {...restProps}
+          />
+        )
       }}
     ></Controller>
   )


### PR DESCRIPTION
## Summary

Enhance the `FormSegmentedControl` component to allow an external `onChange` handler.

## Changes

- Added an `onChange` prop to `FormSegmentedControl` to support external change handling.
- Updated the internal `onChange` logic to call both the internal and external handlers.