### PR TITLE
fix: refactor PropertyCard to use context for props management

### DIFF
--- a/.changeset/perfect-brooms-switch.md
+++ b/.changeset/perfect-brooms-switch.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix: refactor PropertyCard to use context for props management

--- a/packages/uikit/src/biz/PropertyCard/index.tsx
+++ b/packages/uikit/src/biz/PropertyCard/index.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement } from 'react'
+import { createContext, useContext, useMemo } from 'react'
 
 import {
   Card,
@@ -13,38 +13,37 @@ import {
 } from '../../primitive/index.js'
 
 export interface PropertyCardProps extends CardProps {
-  title: string
+  title?: string
   labelProps?: TypographyProps
   valueProps?: TypographyProps
 }
 
-const PropertyCard = ({ title, children, labelProps, valueProps, ...rest }: PropertyCardProps) => {
-  const renderChildren = () => {
-    return Children.map(children, (child) => {
-      if (!child || typeof child !== 'object' || !('props' in child)) {
-        return child
-      }
+interface PropertyCardContextValue {
+  labelProps?: TypographyProps
+  valueProps?: TypographyProps
+}
 
-      return cloneElement(child, {
-        ...child.props,
-        labelProps: {
-          ...labelProps,
-          ...child.props.labelProps
-        },
-        valueProps: {
-          ...valueProps,
-          ...child.props.valueProps
-        }
-      })
-    })
-  }
+const PropertyCardContext = createContext<PropertyCardContextValue | undefined>(undefined)
+
+const PropertyCard = ({ title, children, labelProps, valueProps, ...rest }: PropertyCardProps) => {
+  const contextValue = useMemo(
+    () => ({
+      labelProps,
+      valueProps
+    }),
+    [labelProps, valueProps]
+  )
 
   return (
     <Card p="xl" {...rest}>
-      <Typography variant="headline-sm" mb={16}>
-        {title}
-      </Typography>
-      <Stack gap={16}>{renderChildren()}</Stack>
+      {title && (
+        <Typography variant="headline-sm" mb={16}>
+          {title}
+        </Typography>
+      )}
+      <PropertyCardContext.Provider value={contextValue}>
+        <Stack gap={16}>{children}</Stack>
+      </PropertyCardContext.Provider>
     </Card>
   )
 }
@@ -56,12 +55,22 @@ export interface PropertyCardItemProps extends GroupProps {
 }
 
 const Item = ({ label, children, labelProps, valueProps, ...rest }: PropertyCardItemProps) => {
+  const context = useContext(PropertyCardContext)
+  const mergedLabelProps = {
+    ...context?.labelProps,
+    ...labelProps
+  }
+  const mergedValueProps = {
+    ...context?.valueProps,
+    ...valueProps
+  }
+
   return (
     <Group gap="md" wrap="nowrap" {...rest}>
-      <Typography variant="label-lg" miw={128} {...labelProps}>
+      <Typography variant="label-lg" miw={128} {...mergedLabelProps}>
         {label}
       </Typography>
-      <Typography variant="body-lg" sx={{ wordBreak: 'break-all' }} {...valueProps}>
+      <Typography variant="body-lg" sx={{ wordBreak: 'break-all' }} {...mergedValueProps}>
         {children}
       </Typography>
     </Group>

--- a/stories/uikit/biz/PropertyCard.stories.tsx
+++ b/stories/uikit/biz/PropertyCard.stories.tsx
@@ -104,7 +104,11 @@ export const WithGlobalProps: Story = {
   },
   render: () => {
     return (
-      <PropertyCard title="Global labelProps and valueProps" labelProps={{ miw: 200 }} valueProps={{ color: 'red' }}>
+      <PropertyCard
+        title="Global labelProps and valueProps"
+        labelProps={{ miw: 200 }}
+        valueProps={{ c: 'red', fw: 'bold' }}
+      >
         <PropertyCard.Item label="Name">Cluster0</PropertyCard.Item>
         <PropertyCard.Item label="Status">Available</PropertyCard.Item>
         <PropertyCard.Item label="Tier Type">Dedicated Tier</PropertyCard.Item>


### PR DESCRIPTION
## Summary

Refactor the `PropertyCard` component to utilize context for managing `labelProps` and `valueProps`, enhancing the component's flexibility and maintainability.

## Changes

- Introduced `PropertyCardContext` to provide `labelProps` and `valueProps` to child components.
- Updated the `PropertyCard` to use context for merging props, simplifying the prop handling.
- Enhanced the `PropertyCard` story to demonstrate the new context-based prop usage.