### PR TITLE
fix: enhance CI workflow to include PR branch and commit SHA outputs

### DIFF
--- a/.github/workflows/pr-comment-commands.yml
+++ b/.github/workflows/pr-comment-commands.yml
@@ -12,6 +12,8 @@ jobs:
     outputs:
       command_found: ${{ steps.check_command.outputs.command_found }}
       status_comment_id: ${{ steps.comment_deployment.outputs.comment_id }}
+      pr_branch: ${{ steps.pr_details.outputs.branch }}
+      pr_sha: ${{ steps.pr_details.outputs.sha }}
 
     steps:
       - name: Check for snapshot-release command
@@ -71,6 +73,7 @@ jobs:
     uses: ./.github/workflows/snapshot-release.yml
     with:
       pr_number: ${{ github.event.issue.number }}
+      commit_sha: ${{ needs.handle_commands.outputs.pr_sha }}
     secrets: inherit
 
   notify_result:
@@ -92,6 +95,7 @@ jobs:
               📦 **Version**: \`${{ needs.snapshot_release.outputs.version }}\`
               🏷️ **Tag**: \`experimental\`
               📥 **Install**: \`npm install @tidbcloud/uikit@experimental\`
+              🔗 **npm**: https://www.npmjs.com/package/@tidbcloud/uikit/v/${{ needs.snapshot_release.outputs.version }}?activeTab=readme
 
               You can test this version in your project now.`
             });

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -8,6 +8,10 @@ on:
         description: 'PR number to comment on'
         required: false
         type: string
+      commit_sha:
+        description: 'Commit SHA to build and publish'
+        required: false
+        type: string
     outputs:
       version:
         description: 'Published version'
@@ -27,6 +31,7 @@ jobs:
         # Fetch all history for all branches and tags
         with:
           fetch-depth: 0
+          ref: ${{ inputs.commit_sha || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary



Enhance the continuous integration workflow to include outputs for the pull request branch and commit SHA.



## Changes



- Added outputs for `pr_branch` and `pr_sha` in the CI workflow.

- Updated the snapshot release job to utilize the new `commit_sha` input.

- Modified the workflow to fetch all history for branches and tags based on the provided commit SHA.