### PR TITLE
fix: update footer content and improve page titles in documentation

### DIFF
--- a/packages/documentation/components/Home.tsx
+++ b/packages/documentation/components/Home.tsx
@@ -257,29 +257,6 @@ export default function Home() {
           </div>
         </div>
       </section>
-
-      {/* Footer */}
-      <footer className="py-10 w-full shrink-0 items-center px-4 md:px-6 border-t bg-background/50 backdrop-blur-sm">
-        <div className="container mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
-          <p className="text-xs text-muted-foreground">
-            © {new Date().getFullYear()} TiDB Cloud FE Team. All rights reserved.
-          </p>
-          <nav className="flex gap-4 sm:gap-6">
-            <Link
-              className="text-xs hover:underline underline-offset-4 text-muted-foreground hover:text-foreground"
-              href="#"
-            >
-              Terms of Service
-            </Link>
-            <Link
-              className="text-xs hover:underline underline-offset-4 text-muted-foreground hover:text-foreground"
-              href="#"
-            >
-              Privacy
-            </Link>
-          </nav>
-        </div>
-      </footer>
     </div>
   )
 }

--- a/packages/documentation/pages/_meta.ts
+++ b/packages/documentation/pages/_meta.ts
@@ -8,7 +8,7 @@ export default {
   },
   'cloud-ui': {
     type: 'page',
-    title: 'Cloud UI',
+    title: 'Components',
     theme: {
       typesetting: 'article',
       layout: 'full'
@@ -30,15 +30,15 @@ export default {
       layout: 'full'
     }
   },
+  docs: {
+    type: 'page',
+    title: 'Docs'
+  },
   __rap: {
     type: 'page',
     title: 'RAP API ↗',
     href: 'https://doc.rapapi.cn/',
     newWindow: true
-  },
-  docs: {
-    type: 'page',
-    title: 'Docs'
   },
   '404': {
     type: 'page',
@@ -47,7 +47,6 @@ export default {
       typesetting: 'article'
     }
   },
-
   storybook_link: {
     type: 'page',
     title: 'Storybook ↗',

--- a/packages/documentation/theme.config.tsx
+++ b/packages/documentation/theme.config.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { DocsThemeConfig } from 'nextra-theme-docs'
 import { useConfig } from 'nextra-theme-docs'
 
@@ -36,7 +37,11 @@ const config: DocsThemeConfig = {
     backToTop: true
   },
   footer: {
-    content: <span>TiUI - TiDB Cloud</span>
+    content: (
+      <footer>
+        <p className="text-xs">© {new Date().getFullYear()} TiDB Cloud FE Team. All rights reserved.</p>
+      </footer>
+    )
   },
   darkMode: true,
   sidebar: {


### PR DESCRIPTION
## Summary



This pull request updates the footer content and enhances the page titles in the documentation.



## Changes



- Updated the footer to include the current year and a copyright notice.

- Changed the title of the 'Cloud UI' page to 'Components'.

- Added a new 'Docs' page entry in the configuration.