### PR TITLE
refactor(uikit): simplify TablePagination styles and move them to theme

### DIFF
--- a/.changeset/gorgeous-bears-worry.md
+++ b/.changeset/gorgeous-bears-worry.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+refactor(uikit): simplify TablePagination styles and move them to theme

--- a/packages/uikit/src/biz/Table/TablePagination.tsx
+++ b/packages/uikit/src/biz/Table/TablePagination.tsx
@@ -95,20 +95,6 @@ export const ProTablePagination = <TData extends MRT_RowData>({ table, ...props 
           total={paginationProps?.total ?? numberOfPages}
           value={paginationProps.value ?? pageIndex + 1}
           withEdges={withEdges}
-          styles={mergeStylesList([
-            (theme) => ({
-              control: {
-                border: 'none',
-                color: theme.colors.carbon[9],
-                borderRadius: theme.defaultRadius,
-                '&[data-active]': {
-                  color: theme.colors.carbon[9],
-                  background: theme.colors.carbon[4]
-                }
-              }
-            }),
-            rest.styles
-          ])}
           {...rest}
         />
         {showRowsPerPage && (

--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -3,6 +3,7 @@ import {
   AccordionProps,
   DEFAULT_THEME,
   MantineTheme,
+  PaginationProps,
   RadioIndicatorProps,
   TagsInputProps,
   createTheme,
@@ -1401,6 +1402,34 @@ const theme = createTheme({
           root: {
             backgroundColor: themeColor(theme, 'carbon', 3),
             color: themeColor(theme, 'carbon', 8)
+          }
+        }
+      }
+    },
+    Pagination: {
+      styles: (theme: MantineTheme, _props: PaginationProps, u: EmotionHelpers) => {
+        return {
+          control: {
+            border: 'none',
+            color: themeColor(theme, 'carbon', 9),
+            borderRadius: theme.defaultRadius,
+            backgroundColor: 'transparent',
+            [u.dark]: {
+              color: themeColor(theme, 'carbon', 8)
+            },
+            '&:hover': {
+              [u.light]: {
+                backgroundColor: themeColor(theme, 'carbon', 2)
+              }
+            },
+            '&[data-active]': {
+              color: themeColor(theme, 'carbon', 9),
+              border: `1px solid ${themeColor(theme, 'carbon', 5)}`,
+              background: themeColor(theme, 'carbon', 2),
+              [u.dark]: {
+                color: themeColor(theme, 'carbon', 8)
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Removed inline styles from TablePagination component and added a centralized styles definition for pagination in the theme. This improves maintainability and consistency across the UI.

**Before**
<img width="442" height="184" alt="image" src="https://github.com/user-attachments/assets/513fcb79-8440-43bd-8999-eb0443b3c1d3" />
<img width="489" height="202" alt="image" src="https://github.com/user-attachments/assets/c374b0cc-5979-4901-9636-415492420469" />

**After**
<img width="474" height="301" alt="image" src="https://github.com/user-attachments/assets/0555b44f-976b-4a2c-abae-35922c7c7494" />
<img width="382" height="193" alt="image" src="https://github.com/user-attachments/assets/c26ff55a-b773-40a9-beaf-5bcc94267fef" />

