### PR TITLE
fix(uikit): simplify hover styles in theme

### DIFF
--- a/.changeset/wild-eggs-act.md
+++ b/.changeset/wild-eggs-act.md
@@ -1,0 +1,5 @@
+---
+"@tidbcloud/uikit": patch
+---
+
+fix(uikit): simplify hover styles in theme

--- a/packages/uikit/src/theme/theme.ts
+++ b/packages/uikit/src/theme/theme.ts
@@ -1418,9 +1418,7 @@ const theme = createTheme({
               color: themeColor(theme, 'carbon', 8)
             },
             '&:hover': {
-              [u.light]: {
-                backgroundColor: themeColor(theme, 'carbon', 2)
-              }
+              backgroundColor: themeColor(theme, 'carbon', 2)
             },
             '&[data-active]': {
               color: themeColor(theme, 'carbon', 9),


### PR DESCRIPTION
Removed unnecessary nested styles for hover state in the theme, streamlining the CSS for better readability and maintainability.